### PR TITLE
buildが落ちないようにconfigの修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,9 @@ export default defineConfig({
             purpose: 'maskable'
           }
         ]
+      },
+      workbox: {
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
       }
     }),
     TanStackRouterVite({


### PR DESCRIPTION
## issue

resolve #65

## description

vite-plugin-pwaのworkbox.maximumFileSizeToCacheInBytesを5MBに修正した

## screenshots (optional)


